### PR TITLE
[feat]: adicionando docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   loja-do-valdir:
     build:
       context: .
-      dockerfile: src/Dockerfile
+      dockerfile: src/LojaDoValdir/Dockerfile
     image: loja-valdir:latest
     container_name: loja-do-valdir
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,33 @@
-version: '3.4'
-
 services:
-  lojadovaldir:
-    image: lojadovaldir
+  loja-do-valdir:
     build:
       context: .
-      dockerfile: src/LojaDoValdir/Dockerfile
+      dockerfile: src/Dockerfile
+    image: loja-valdir:latest
+    container_name: loja-do-valdir
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+    networks:
+      - loja-network  # Adicionando a rede aqui
+
+  db:
+    image: postgres:13
+    container_name: loja-db
+    environment:
+      POSTGRES_DB: loja-db
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: password
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    networks:
+      - loja-network
+
+networks:
+  loja-network:
+    driver: bridge
+
+volumes:
+  db-data:
+    driver: local

--- a/src/LojaDoValdir/Dockerfile
+++ b/src/LojaDoValdir/Dockerfile
@@ -1,23 +1,27 @@
 # Etapa base do runtime
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+LABEL maintainder "Hisllaylla Kézia"
 WORKDIR /app
 EXPOSE 8080
 
 # Etapa de build
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-WORKDIR /source
-COPY ["LojaDoValdir.csproj", "."]
-RUN dotnet restore "LojaDoValdir.csproj"
-COPY . .
-WORKDIR "/source"
+WORKDIR /src
+
+COPY src/LojaDoValdir/LojaDoValdir.csproj LojaDoValdir/
+RUN dotnet restore "LojaDoValdir/LojaDoValdir.csproj"
+
+COPY src .
+
+WORKDIR "/src/LojaDoValdir"
 RUN dotnet build "LojaDoValdir.csproj" -c Release -o /app/build
 
 # Etapa de publicação
 FROM build AS publish
-RUN dotnet publish "LojaDoValdir.csproj" -c Release -o /app/publish /p:UseAppHost=false
+RUN dotnet publish "LojaDoValdir.csproj" -c Release -o /app/publish
 
 # Etapa final
-FROM base AS final
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
 WORKDIR /app
 COPY --from=publish /app/publish .
 ENTRYPOINT ["dotnet", "LojaDoValdir.dll"]

--- a/src/LojaDoValdir/Properties/appsettings.json
+++ b/src/LojaDoValdir/Properties/appsettings.json
@@ -1,0 +1,12 @@
+{
+    "Logging": {
+      "LogLevel": {
+        "Default": "Information",
+        "Microsoft.AspNetCore": "Warning"
+      }
+    },
+    "AllowedHosts": "*",
+    "ConnectionStrings": {
+      "DefaultConnection": "Host=loja-db;Database=loja_db;Username=user;Password=password"
+    }
+}  


### PR DESCRIPTION
Após clonar o projeto ou, no caso de usar o Codespace, em vez de acessar direto a `src/LojaDoValdir`, siga o passo a passo abaixo para executar o `docker-compose`, que será responsável por orquestrar as imagens do banco de dados e da aplicação.
> Certifique-se que não há imagens pré-carregadas com `sudo docker images -a` e caso tenha, utilize: `sudo docker rmi --force <id-image>` para apagá-las, assim não comprometendo o funcionamento do docker-compose.

1. Após iniciar o ambiente, é possível verificar os containers com:
```
sudo docker compose ps
```
 
2. Para criar, recriar e iniciar diretamente, utilize:
```
sudo docker compose up
```
> A aplicação pode ser acessada via navegador digitando `localhost:8080` ou `localhost:8080/index.html` para acessar a Swagger API.

3. Para interromper os containers, utilize `CTRL + C`, que os colocará no estado _stopped_. 
4. Caso queira reiniciar os serviços em background/segundo plano, utilize:
```
sudo docker compose up -d
```
> O comando `sudo docker compose up` pode ser utilizado novamente para reativar os containers.
5. Os containers do projeto são `loja-do-valdir` e `db-loja`. Para listar os containers em execução, use: 
```
sudo docker compose ps
```
6. Para depuração, os logs podem ser visualizados com `sudo docker compose logs`. 
> Volumes criados pelo `docker-compose` podem ser listados com `sudo docker volume ls`.
7. Caso seja necessário pausar um container, utilize `sudo docker pause <nome-container>`. 
> Para retomar a execução de um container pausado, use `sudo docker unpause <nome-container>`.
8. Para verificar o histórico dos containers, execute `sudo docker compose ps`. 
> Se for necessário parar ou remover os containers, utilize `sudo docker compose down`. Para remover também volumes e dados armazenados, use `sudo docker compose down -v`.