### PR TITLE
[feat]: conectando DockerHub

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,16 +1,11 @@
 name: Main Check Build
 
-# triggers-gatilhos
-
-on: 
+on:
   pull_request:
-    branches: 
+    branches:
       - main
-  
-# passo a passo
 
 jobs:
-
   build-ubuntu:
     runs-on: ubuntu-latest
     steps:
@@ -27,3 +22,24 @@ jobs:
 
       - name: Build Application
         run: dotnet build --configuration Release --no-restore
+
+      - name: Build and Run Docker Container
+        run: |
+          docker build -t loja-valdir:latest -f src/LojaDoValdir/Dockerfile .
+          docker run -d -p 8080:8080 --name loja-valdir loja-valdir:latest
+          sleep 10  # Aguarda um tempo para garantir que a aplicação iniciou
+
+      - name: Test Healthcheck Endpoint
+        run: |
+          for i in {1..20}; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/healthcheck)
+            if [ "$STATUS" -eq 200 ]; then
+              echo "Healthcheck passed with status $STATUS"
+              exit 0
+            else
+              echo "Healthcheck attempt $i failed with status $STATUS. Retrying..."
+              sleep 2
+            fi
+          done
+          echo "Healthcheck failed after 20 attempts."
+          exit 1

--- a/.github/workflows/main-realese.yml
+++ b/.github/workflows/main-realese.yml
@@ -24,8 +24,35 @@ jobs:
       - name: Build Application
         run: dotnet build --configuration Release --no-restore
 
+  build-push-image:
+    needs: setup-build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          file: ./src/LojaDoValdir/Dockerfile
+          tags: ${{ secrets.DOCKERHUB_USERNAME }} /loja-do-valdir:latest
+
   container-test: # cria um container Docker e testa o endpoint de healthcheck
-    needs: setup-build  # Só executa se o setup-build passar
+    needs: build-push-image
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
@@ -33,18 +60,22 @@ jobs:
 
       - name: Build and Run Docker Container
         run: |
-          docker build -t loja-valdir:latest -f src/LojaDoValdir/Dockerfile .
-          docker run -d -p 8080:8080 --name loja-valdir loja-valdir:latest
-          sleep 10  # Aguarda um tempo para garantir que a aplicação iniciou
+          docker run -d -p 8080:8080 --name loja-valdir ${{ secrets.DOCKERHUB_USERNAME }}/loja-do-valdir:latest
+          sleep 10
 
       - name: Test Healthcheck Endpoint
         run: |
-          STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/healthcheck)
-          if [ "$STATUS" -ne 200 ]; then
-            echo "Healthcheck failed with status $STATUS"
-            exit 1
-          fi
-          echo "Healthcheck passed with status $STATUS"
+          for i in {1..20}; do
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/healthcheck)
+            if [ "$STATUS" -eq 200 ]; then
+              echo "Healthcheck passed!"
+              exit 0
+            fi
+            echo "Healthcheck attempt $i failed with status $STATUS. Retrying..."
+            sleep 2
+          done
+          echo "Healthcheck failed after 20 attempts."
+          exit 1
 
       - name: Cleanup
         run: docker stop loja-valdir && docker rm loja-valdir

--- a/src/LojaDoValdir/LojaDoValdir.sln
+++ b/src/LojaDoValdir/LojaDoValdir.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.2.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LojaDoValdir", "LojaDoValdir.csproj", "{776682A6-DF00-A7FB-C49A-2E09F5287E5F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{776682A6-DF00-A7FB-C49A-2E09F5287E5F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{776682A6-DF00-A7FB-C49A-2E09F5287E5F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{776682A6-DF00-A7FB-C49A-2E09F5287E5F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{776682A6-DF00-A7FB-C49A-2E09F5287E5F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0E83EF14-A554-4F5A-BCBD-8AF86770847D}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Dada a issue #60, este PR implementa a pipeline `main-release.yml` que automatiza o processo de build, publicação e teste da imagem Docker do projeto **Loja do Valdir** na conta do Docker Hub.  
  
## Feitos
1. **Conta no Docker Hub:**  

![Captura de tela de 2025-02-17 19-44-37](https://github.com/user-attachments/assets/14f0d7d6-6d51-4df7-912b-3e977594c118)

2. **Segurança e Credenciais:**  

![Captura de tela de 2025-02-17 19-58-59](https://github.com/user-attachments/assets/7f9e5d69-2d2d-4178-ac24-fe477944e9d6)

> obs: vale comentar que adicionei o `container-test` na `main-release`. Ele sobe o container usando a imagem publicada e realiza um teste no endpoint `/healthcheck`, onde realiza até 20 tentativas (com intervalos de 2 segundos) para verificar se o `healthcheck` responde com status 200, garantindo que o container tenha tempo suficiente para inicializar, e, caso algo falhe, ele sinaliza o número do status de erro. Ao final, o container é limpo para não deixar resíduos no runner.

### Como testar:
1. **Baixe a imagem:**
   ```
   docker pull hisllaylla/loja-do-valdir:latest
   ```
2. **Suba os containers:**
   ```
   docker compose up
   ```
3. **Verifique os containers em execução:**
   ```
   docker ps
   ```
4. **Teste o endpoint de healthcheck:**
   ```
   curl http://localhost:8080/healthcheck
   ```
![Captura de tela de 2025-02-17 19-41-31](https://github.com/user-attachments/assets/e0d94c09-b288-465f-84eb-8d82a1a68ad9)


